### PR TITLE
Add better cursor tracking when typing quickly

### DIFF
--- a/rt-shell/objects/obj_shell/Step_0.gml
+++ b/rt-shell/objects/obj_shell/Step_0.gml
@@ -20,7 +20,7 @@ if (!isOpen) {
 	} else if (keyboard_string != "") {
 		var t = keyboard_string;
 		consoleString = string_insert(t, consoleString, cursorPos);
-		cursorPos += 1;
+		cursorPos += string_length(t);
 		keyboard_string = "";
 	} else if (keyboardCheckDelay(vk_left)) { 
 		cursorPos = max(1, cursorPos - 1);


### PR DESCRIPTION
If you typed fast enough, the game would register more than one character typed per frame. Since the cursor was only being moved one character, the cursor would desync from where it should actually be in the string. By changing `cursorPos += 1;` to `cursorPos += string_length(t);`, this fixes it.