### PR TITLE
#1 : Add autocomplete

### DIFF
--- a/rt-shell/objects/obj_shell/CleanUp_0.gml
+++ b/rt-shell/objects/obj_shell/CleanUp_0.gml
@@ -1,3 +1,4 @@
 surface_free(shellSurface);
 ds_list_destroy(history);
 ds_list_destroy(output);
+ds_list_destroy(filteredFunctions);

--- a/rt-shell/objects/obj_shell/Draw_64.gml
+++ b/rt-shell/objects/obj_shell/Draw_64.gml
@@ -20,6 +20,15 @@ surface_set_target(shellSurface);
 		draw_text(10 + string_width(prompt) + string_width(string_copy(consoleString + " ", 1, cursorPos - 1)) - 3, height - lineHeight, "|");
 	}
 	
+	// Draw an autocomplete suggestion
+	if (ds_list_size(filteredFunctions) != 0) {
+		draw_set_alpha(consoleAlpha/2);
+		var ff = filteredFunctions[| suggestionIndex];
+		var suggestion = string_copy(ff, string_length(consoleString) + 1, string_length(ff) - string_length(consoleString));
+		draw_text(10 + string_width(prompt) + string_width(consoleString), height - lineHeight, suggestion);
+		draw_set_alpha(consoleAlpha);
+	}
+	
 	// Draw some lines of previous output
 	draw_set_alpha(consoleAlpha/2);
 	var outputSize = ds_list_size(output);

--- a/rt-shell/objects/obj_shell/Step_0.gml
+++ b/rt-shell/objects/obj_shell/Step_0.gml
@@ -81,13 +81,15 @@ if (!isOpen) {
 			cursorPos = 1;
 		}
 	} else if (keyboard_check_pressed(vk_tab)) {
-		// Auto-complete up to the common prefix of our suggestions
-		var uncompleted = consoleString;
-		consoleString = findCommonPrefix();
-		cursorPos = string_length(consoleString) + 1;
-		// If we're already autocompleted as far as we can go, rotate through suggestions
-		if (uncompleted == consoleString) {
-			suggestionIndex = (suggestionIndex + 1) % ds_list_size(filteredFunctions);
+		if (ds_list_size(filteredFunctions) != 0) {
+			// Auto-complete up to the common prefix of our suggestions
+			var uncompleted = consoleString;
+			consoleString = findCommonPrefix();
+			cursorPos = string_length(consoleString) + 1;
+			// If we're already autocompleted as far as we can go, rotate through suggestions
+			if (uncompleted == consoleString) {
+				suggestionIndex = (suggestionIndex + 1) % ds_list_size(filteredFunctions);
+			}
 		}
 	}
 	

--- a/rt-shell/rt-shell.yyp
+++ b/rt-shell/rt-shell.yyp
@@ -47,7 +47,7 @@
   ],
   "IncludedFiles": [],
   "MetaData": {
-    "IDEVersion": "23.1.1.175",
+    "IDEVersion": "2.3.0.529",
   },
   "resourceVersion": "1.3",
   "name": "rt-shell",


### PR DESCRIPTION
This merge request adds the ability to autocomplete functions.

When the shell object first spawns a list of all global `sh_` functions is created.

As the user types, that list is filtered to just the results prefixed with the user's current console string.

A first press of tab fills in the console string up to the common point of all the filtered suggestions:
> i.e. if the user had type `se` and the suggestions were `set_hspeed` and `set_vspeed`, the first tab press would fill in the console string up to `set_`

Second and subsequent tab presses will rotate through the filtered suggestions (they are shown in half-opacity text completing what the user typed).

Pressing the right arrow key when the cursor is at the end position will accept the current suggestion and fill in the console string all the way with that single suggestion.

Closes #1 