### PR TITLE
Close #23, Close #25 - Fix clear script, fix scrolling to first line, & smooth scrolling options

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ You can see examples of various ways to customize the shell's appearance on the 
 | `keyRepeatInitialDelay` | The amount of time in frames to wait after pressing and holding a key before it begins to repeat. | 25 |
 | `keyRepeatDelay` | The amount of time in frames to wait between each repeat of a held key. | 4 |
 | `scrollSpeed` | The number of pixels at a time to scroll the console when moving the mouse wheel. | 16 |
+| `scrollSmoothness` | How smooth you want the scrolling to be when moving the mouse wheel. A number between 0 - 1. | 0.5 |
 
 ## Licensing
 

--- a/rt-shell/objects/obj_shell/Create_0.gml
+++ b/rt-shell/objects/obj_shell/Create_0.gml
@@ -13,6 +13,7 @@ consoleString = "";
 savedConsoleString = "";
 scrollPosition = 0;
 maxScrollPosition = 0;
+targetScrollPosition = 0;
 commandSubmitted = false; // Need to update scroll position one frame after a command is submitted
 insertMode = true;
 
@@ -321,4 +322,14 @@ function array_contains(array, element) {
 		}
 	}
 	return false;
+}
+
+/// @param value
+/// @param min_input
+/// @param max_input
+/// @param min_output
+/// @param max_output
+function remap(value, min_input, max_input, min_output, max_output) {
+	var _t = (value - min_input) / (max_input - min_input);
+	return lerp(min_output, max_output, _t);
 }

--- a/rt-shell/objects/obj_shell/Draw_64.gml
+++ b/rt-shell/objects/obj_shell/Draw_64.gml
@@ -27,12 +27,10 @@ if (isOpen) {
 	// Updating this here removes jitter as the scroll bar draws one frame in the old position
 	// and then jumps to the bottom. This fixes that
 	if (commandSubmitted) {
-		maxScrollPosition = max(0, outputHeight - visibleHeight);
+		maxScrollPosition = max(0, outputHeight - visibleHeight + emHeight);
 		scrollPosition = maxScrollPosition;
 		commandSubmitted = false;
 	}
-	
-	
 	
 	surface_set_target(scrollSurface);
 		draw_clear_alpha(c_black, 0.0);
@@ -42,9 +40,8 @@ if (isOpen) {
 		// the bottom of the panel
 		if (outputHeight < visibleHeight - emHeight) {
 			yOffset += visibleHeight - outputHeight - emHeight;
-		} else {
-			yOffset -= emHeight;
 		}
+		
 		
 		// Draw output history
 		for (var i = 0; i < array_length(output); i++) {
@@ -127,7 +124,7 @@ if (isOpen) {
 		draw_surface(scrollSurface, 0, shellOriginY + 1 + consolePaddingV);
 		
 		// Draw scrollbar
-		if (outputHeight > visibleHeight) {
+		if (outputHeight > visibleHeight - emHeight) {
 			var x1 = shellOriginX + width - consolePaddingH - scrollbarWidth;
 			var y1 = shellOriginY + consolePaddingV + 1;
 			var x2 = x1 + scrollbarWidth;
@@ -138,8 +135,8 @@ if (isOpen) {
 			
 			var containerHeight = y2 - y1;
 			
-			var scrollProgress = scrollPosition / (outputHeight - visibleHeight);
-			var scrollbarHeight = (visibleHeight / outputHeight) * containerHeight;
+			var scrollProgress = scrollPosition / (outputHeight - visibleHeight + emHeight);
+			var scrollbarHeight = (visibleHeight / (outputHeight + emHeight)) * containerHeight;
 			var scrollbarPosition = (containerHeight - scrollbarHeight) * scrollProgress;
 			
 			y1 = y1 + scrollbarPosition;

--- a/rt-shell/objects/obj_shell/Draw_64.gml
+++ b/rt-shell/objects/obj_shell/Draw_64.gml
@@ -28,7 +28,8 @@ if (isOpen) {
 	// and then jumps to the bottom. This fixes that
 	if (commandSubmitted) {
 		maxScrollPosition = max(0, outputHeight - visibleHeight + emHeight);
-		scrollPosition = maxScrollPosition;
+		if (scrollSmoothness == 0) { scrollPosition = maxScrollPosition; }
+		targetScrollPosition = maxScrollPosition;
 		commandSubmitted = false;
 	}
 	

--- a/rt-shell/objects/obj_shell/Other_10.gml
+++ b/rt-shell/objects/obj_shell/Other_10.gml
@@ -74,7 +74,8 @@ variable_global_set("sh_clear", function(args) {
 		return "";
 	} else {
 		array_push(output, ">" + consoleString);
-		var _newLinesCount = floor(height / string_height(prompt)) - 1;
+		draw_set_font(consoleFont);
+		var _newLinesCount = floor(visibleHeight / string_height(prompt));
 		repeat(_newLinesCount) {
 			array_push(output, "\n");
 		}

--- a/rt-shell/objects/obj_shell/Step_0.gml
+++ b/rt-shell/objects/obj_shell/Step_0.gml
@@ -4,7 +4,7 @@ if (!isOpen) {
 	}
 } else {
 	var prevConsoleString = consoleString;
-	maxScrollPosition = max(0, outputHeight - visibleHeight);
+	//maxScrollPosition = max(0, outputHeight - visibleHeight);
 	
 	if (keyboard_check_pressed(vk_escape)) {
 		if (isAutocompleteOpen) {

--- a/rt-shell/objects/obj_shell/obj_shell.yy
+++ b/rt-shell/objects/obj_shell/obj_shell.yy
@@ -88,6 +88,7 @@
     {"varType":0,"value":"25","rangeEnabled":false,"rangeMin":0.0,"rangeMax":10.0,"listItems":[],"multiselect":false,"filters":[],"resourceVersion":"1.0","name":"keyRepeatInitialDelay","tags":[],"resourceType":"GMObjectProperty",},
     {"varType":0,"value":"4","rangeEnabled":false,"rangeMin":0.0,"rangeMax":10.0,"listItems":[],"multiselect":false,"filters":[],"resourceVersion":"1.0","name":"keyRepeatDelay","tags":[],"resourceType":"GMObjectProperty",},
     {"varType":0,"value":"16","rangeEnabled":false,"rangeMin":0.0,"rangeMax":10.0,"listItems":[],"multiselect":false,"filters":[],"resourceVersion":"1.0","name":"scrollSpeed","tags":[],"resourceType":"GMObjectProperty",},
+    {"varType":0,"value":"0.5","rangeEnabled":true,"rangeMin":0.0,"rangeMax":1.0,"listItems":[],"multiselect":false,"filters":[],"resourceVersion":"1.0","name":"scrollSmoothness","tags":[],"resourceType":"GMObjectProperty",},
   ],
   "overriddenProperties": [],
   "parent": {


### PR DESCRIPTION
- We weren't taking the prompt height into account (emHeight) when considering maxScrollPosition and the scrollbar calculations.
- The clear function wasn't taking the correct font into account and also switched it to use visibleHeight instead of Height. Since our shell can be configured per pixel, this won't be a perfect calculation of how many lines to put in, but it errs on the side of putting in one extra instead of one fewer. (So the console log is always blank after the clear command instead of showing a bit of the clear output)