### PR TITLE
Enable runtime argument suggestions

### DIFF
--- a/rt-shell/objects/obj_shell/Create_0.gml
+++ b/rt-shell/objects/obj_shell/Create_0.gml
@@ -127,7 +127,11 @@ function updateFilteredSuggestions() {
 		if (dataExists && noExtraSpace && spaceCount <= array_length(inputArray)) {
 			var suggestionData = functionData[$ inputArray[0]][$ "suggestions"];
 			if (argumentIndex < array_length(suggestionData)) {
-				var argumentSuggestions = suggestionData[argumentIndex];
+				if (is_array(suggestionData[argumentIndex])) {
+					var argumentSuggestions = suggestionData[argumentIndex];
+				} else {
+					var argumentSuggestions = suggestionData[argumentIndex]();
+				}
 				var currentArgument = inputArray[array_length(inputArray) - 1];
 				for (var i = 0; i < array_length(argumentSuggestions); i++) {
 					var prefixMatch = string_pos(currentArgument, string_lower(argumentSuggestions[i])) == 1;


### PR DESCRIPTION
Instead of passing in a direct array into the meta struct, you can define an anonymous function to return an array of suggestions instead.

Example for how I use this:
```gml
function sh_layer_toggle(args) {
	layer_set_visible(args[0], !layer_get_visible(args[0]));
}

function meta_layer_toggle() {
	return {
		description: "Control Layers",
		arguments: ["layer_name"],
		suggestions: [
			function() {
				var _layers = layer_get_all();
				for (var i = array_length(_layers) - 1; i >= 0; --i) {
					if (string_pos("_layer_", layer_get_name(_layers[i])) == 1) {
						array_delete(_layers, i, 1);
					} else {
						_layers[i] = layer_get_name(_layers[i]);
					}
				}
				return _layers;
			}
		],
		argumentDescriptions: [
			"The name of the layer you want to toggle."
		]
	}
}
```