### PR TITLE
Fix empty commands from executing

### DIFF
--- a/rt-shell/objects/obj_shell/Step_0.gml
+++ b/rt-shell/objects/obj_shell/Step_0.gml
@@ -150,35 +150,42 @@ if (!isOpen) {
 		}
 		targetScrollPosition = maxScrollPosition;
 	} else if (keyboard_check_pressed(vk_enter)) {
-		if (isAutocompleteOpen) {
-			self._confirm_current_suggestion();
-		} else {
-			var args = self._input_string_split(consoleString);
-			if (array_length(args) > 0) {
-				var metadata = functionData[$ args[0]];
-				if (!is_undefined(metadata)) {
-					var deferred = false;
-					if (variable_struct_exists(metadata, "deferred")) {
-						deferred = metadata.deferred;
-					}
-					if (deferred) {
-						ds_queue_enqueue(deferredQueue, args);
-						array_push(history, consoleString);
-						array_push(output, ">" + consoleString);
-						array_push(output, "Execution deferred until shell is closed.");
-						self._update_positions();
+		if (string_trim(consoleString) != "") {
+			if (isAutocompleteOpen) {
+				self._confirm_current_suggestion();
+			} else {
+				var args = self._input_string_split(consoleString);
+				if (array_length(args) > 0) {
+					var metadata = functionData[$ args[0]];
+					if (!is_undefined(metadata)) {
+						var deferred = false;
+						if (variable_struct_exists(metadata, "deferred")) {
+							deferred = metadata.deferred;
+						}
+						if (deferred) {
+							ds_queue_enqueue(deferredQueue, args);
+							array_push(history, consoleString);
+							array_push(output, ">" + consoleString);
+							array_push(output, "Execution deferred until shell is closed.");
+							self._update_positions();
+						} else {
+							_execute_script(args);
+						}
 					} else {
 						_execute_script(args);
 					}
 				} else {
-					_execute_script(args);
+					array_push(output, ">");
+					consoleString = "";
+					savedConsoleString = "";
+					cursorPos = 1;
 				}
-			} else {
-				array_push(output, ">");
-				consoleString = "";
-				savedConsoleString = "";
-				cursorPos = 1;
 			}
+		} else {
+			array_push(output, ">");
+			consoleString = "";
+			savedConsoleString = "";
+			cursorPos = 1;
 		}
 		commandSubmitted = true;
 	} else if (self._key_combo_pressed(cycleSuggestionsModifiers, cycleSuggestionsKey)) {


### PR DESCRIPTION
When submitting an empty string as a command, the shell spits out a warning message `No such command:`.

![Runner_qlTmRad1dQ](https://github.com/daikon-games/rt-shell/assets/20096702/70ff75d2-ea02-452d-8020-b951b98a78f9)

This change will still add the string to the history, but not spit out a warning message on empty string.

![Runner_CoVPx5h2dx](https://github.com/daikon-games/rt-shell/assets/20096702/74c17d04-923e-4b9e-9949-128651c04464)
